### PR TITLE
docs: Add maven as prerequisite

### DIFF
--- a/blocks/messages-service/README.md
+++ b/blocks/messages-service/README.md
@@ -5,19 +5,24 @@ Kapeta block implemented using Language Target "Java Spring Boot"
 See the [kapeta.md](kapeta.md) readme file for more information.
 
 ## Prerequisites
+
 - Docker installed and running
 - Kapeta Desktop installed and running
 - Java 21+
+- Maven
 
 ## Setup
 
 To prepare / setup the service, run the following command:
+
 ```bash
 mvn compile
 ```
 
 ## Running
+
 To run the service, use the following commands:
+
 ```bash
 mvn spring-boot:run
 ```


### PR DESCRIPTION
I found out yesterday that I didn't have maven installed on my machine. The `messages-service` couldn't start until I installed it.